### PR TITLE
Renew authorkit exercise

### DIFF
--- a/download-ak-exercise.php
+++ b/download-ak-exercise.php
@@ -2,50 +2,9 @@
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 
-require_once('initTsugi.php');
-include('views/dao/menu.php'); // for -> $menu
+// include('views/dao/menu.php'); // for -> $menu
 include('util/Functions.php');
-
-
-
-global $REST_CLIENT_AUTHOR, $REST_CLIENT_REPO;
 
 $exerciseId = $_GET['exerciseId'];
 
-$exerciseFileResponse = $REST_CLIENT_AUTHOR->getClient()->request('GET', "exercises/$exerciseId/export?format=zip", [
-    'buffer' => false,
-]);
-
-if (200 !== $exerciseFileResponse->getStatusCode()) {
-    throw new \Exception('Request to AK failed');
-}
-$headers = $exerciseFileResponse->getHeaders();
-$filename = getFilenameFromDisposition($headers['content-disposition'][0]);
-
-
-$fileHandler = fopen($filename, 'w');
-foreach ($REST_CLIENT_AUTHOR->getClient()->stream($exerciseFileResponse) as $chunk) {
-    fwrite($fileHandler, $chunk->getContent());
-}
-
-
-$formFields = [
-    'PHPSESSID' => session_id(),
-    'exercise' => DataPart::fromPath($filename),
-    'sessionLanguage' =>$TSUGI_LOCALE
-];
-$formData = new FormDataPart($formFields);
-
-$uploadResponse = $REST_CLIENT_REPO->getClient()->request('POST', 'api/exercises/import-file', [
-    'headers' => $formData->getPreparedHeaders()->toArray(),
-    'body' => $formData->bodyToIterable(),
-    
-]);
-
-
-$uploadResponseCode = $uploadResponse->getStatusCode();
-$uploadResponseBody = $uploadResponse->getContent();
-
-unlink($filename);
-
-echo $uploadResponseBody;
+echo downloadAkExercise($exerciseId);

--- a/student-home.php
+++ b/student-home.php
@@ -16,7 +16,7 @@ $user = new \CT\CT_User($user_id);
 if ($totalExercises > 0) {
 
     $firstExerciseAkId = $exercises[$currentExerciseNumber - 1]->getAkId();
-    $firsExerciseId = $exercises[$currentExerciseNumber - 1]->getExerciseId();
+    $firstExerciseId = $exercises[$currentExerciseNumber - 1]->getExerciseId();
     if ( $USER->instructor ) {
         $renewed = downloadAkExercise($firstExerciseAkId);
     }
@@ -24,31 +24,31 @@ if ($totalExercises > 0) {
     $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements/$student_language");
     $statements_list = $exerciseStatementsResponse->toArray();
     $testsList = $exerciseTestsResponse->toArray();
-}
 
-if (count(array_filter($statements_list, 'is_null')) == count($statements_list)) {
-    $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements/en");
-    $statements_list = $exerciseStatementsResponse->toArray();
-}
-
-if (count(array_filter($statements_list, 'is_null')) == count($statements_list)) {
-    $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements");
-    $statements_list = $exerciseStatementsResponse->toArray();
-}
-
-foreach ($statements_list as $statement) {
-    if ($statement) {
-        $statement_value = $statement['statementValue'];
+    if (count(array_filter($statements_list, 'is_null')) == count($statements_list)) {
+        $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements/en");
+        $statements_list = $exerciseStatementsResponse->toArray();
     }
-}
 
-$code_languages = $validatorService->getCodeLanguages();
-$last_used_language = isset($_SESSION["last_used_language"]) ? $_SESSION["last_used_language"] : "";
+    if (count(array_filter($statements_list, 'is_null')) == count($statements_list)) {
+        $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements");
+        $statements_list = $exerciseStatementsResponse->toArray();
+    }
 
-foreach ($code_languages as $indice => $language) {
-    if ($last_used_language == $language) {
-        unset($code_languages[$indice]);
-        array_unshift($code_languages, $last_used_language);
+    foreach ($statements_list as $statement) {
+        if ($statement) {
+            $statement_value = $statement['statementValue'];
+        }
+    }
+
+    $code_languages = $validatorService->getCodeLanguages();
+    $last_used_language = isset($_SESSION["last_used_language"]) ? $_SESSION["last_used_language"] : "";
+
+    foreach ($code_languages as $indice => $language) {
+        if ($last_used_language == $language) {
+            unset($code_languages[$indice]);
+            array_unshift($code_languages, $last_used_language);
+        }
     }
 }
 
@@ -58,12 +58,12 @@ echo $twig->render('pages/student-view.php.twig', array(
     'menu' => $menu,
     'user' => $user,
     // Return true when have a correct usage if not returns false
-    'correctUsage' => $user->getHaveCorrectUsage($firsExerciseId, $user_id),
+    'correctUsage' => $firstExerciseId ? $user->getHaveCorrectUsage($firstExerciseId, $user_id) : false,
     // All codelanguages but ordened by last used language
-    'codeLanguagesOrdened' => $code_languages,
+    'codeLanguagesOrdened' => isset($code_languages) ? $code_languages : null,
     'exercises' => $exercises,
-    'statementValue' => $statement_value,
-    'testsList' => $testsList,
+    'statementValue' => isset($statement_value) ? $statement_value : null,
+    'testsList' => isset($testsList) ? $testsList : null,
     'totalExercises' => $totalExercises,
     'currentExerciseNumber' => $currentExerciseNumber,
     'exerciseNum' => $currentExerciseNumber,

--- a/student-home.php
+++ b/student-home.php
@@ -1,6 +1,7 @@
 <?php
 require_once('initTsugi.php');
 include('views/dao/menu.php');
+include('util/Functions.php');
 
 $SetID = $_SESSION["ct_id"];
 $main = new \CT\CT_Main($_SESSION["ct_id"]);
@@ -16,6 +17,9 @@ if ($totalExercises > 0) {
 
     $firstExerciseAkId = $exercises[$currentExerciseNumber - 1]->getAkId();
     $firsExerciseId = $exercises[$currentExerciseNumber - 1]->getExerciseId();
+    if ( $USER->instructor ) {
+        $renewed = downloadAkExercise($firstExerciseAkId);
+    }
     $exerciseTestsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/tests");
     $exerciseStatementsResponse = $REST_CLIENT_REPO->getClient()->request('GET', "api/exercises/$firstExerciseAkId/statements/$student_language");
     $statements_list = $exerciseStatementsResponse->toArray();

--- a/util/Functions.php
+++ b/util/Functions.php
@@ -1,4 +1,8 @@
 <?php
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+
+require_once('initTsugi.php');
 
 function getFilenameFromDisposition($value) {
     $value = trim($value);
@@ -45,3 +49,42 @@ function getFilenameFromDisposition($value) {
 
     return $filename;
 }
+
+function downloadAkExercise($exerciseId) {
+
+    global $REST_CLIENT_AUTHOR, $REST_CLIENT_REPO, $TSUGI_LOCALE;
+
+    $exerciseFileResponse = $REST_CLIENT_AUTHOR->getClient()->request('GET', "exercises/$exerciseId/export?format=zip", [
+        'buffer' => false,
+    ]);
+
+    if (200 !== $exerciseFileResponse->getStatusCode()) {
+        throw new \Exception('Request to AK failed');
+    }
+    $headers = $exerciseFileResponse->getHeaders();
+    $filename = getFilenameFromDisposition($headers['content-disposition'][0]);
+
+    $fileHandler = fopen($filename, 'w');
+    foreach ($REST_CLIENT_AUTHOR->getClient()->stream($exerciseFileResponse) as $chunk) {
+        fwrite($fileHandler, $chunk->getContent());
+    }
+
+    $formFields = [
+        'PHPSESSID' => session_id(),
+        'exercise' => DataPart::fromPath($filename),
+        'sessionLanguage' =>$TSUGI_LOCALE
+    ];
+    $formData = new FormDataPart($formFields);
+
+    $uploadResponse = $REST_CLIENT_REPO->getClient()->request('POST', 'api/exercises/import-file', [
+        'headers' => $formData->getPreparedHeaders()->toArray(),
+        'body' => $formData->bodyToIterable(),
+
+    ]);
+
+    $uploadResponseCode = $uploadResponse->getStatusCode();
+    $uploadResponseBody = $uploadResponse->getContent();
+
+    unlink($filename);
+    return $uploadResponseBody;
+    }


### PR DESCRIPTION
In this branch there are two different commits:

1. When the instructors used exercises created in Authorkit and, after that, they edited them, codetest doesn't updated the exercises. Using this commit, when instructor try an exercise in student-view, renew the exercise in codetest.
2. The changes made to show the right language, generate an error when the context doesn't include no one exercise. Now, the previous code is included into `if ($totalExercises > 0) {`
